### PR TITLE
Add FE PR template

### DIFF
--- a/PULL_REQUEST_TEMPLATE/front-end
+++ b/PULL_REQUEST_TEMPLATE/front-end
@@ -1,0 +1,46 @@
+# Front-End Pull Request
+
+### **Description**
+<!-- Uncomment one or more of the following change categories and add bullet point notes underneath summarizing your changes: -->
+
+<!-- - Bug fix -->
+<!-- - New feature -->
+<!-- - Refactor (non-breaking changes) -->
+<!-- - Documentation update -->
+<!-- - Proof of concept -->
+<!-- - Other (please specify): -->
+
+---
+
+### **Related Issues**
+<!-- Add link to the related Kantata task in the parenthesis below. Follow the same format to add additional Kantata Task links if needed.-->
+
+- [Kantata Task]()
+<!-- - [Kantata Task #2]()-->
+
+---
+
+### **Additional Notes**
+<!-- Include any additional information that reviewers should know. For example, known issues, caveats, incomplete work will be handled in a separate PR, or limitations in this PR. -->
+
+---
+
+### **Demo**
+
+<!-- Add screenshots or links to preview pages demonstrating your changes. -->
+
+---
+
+### **Additional Resources**
+
+<!-- Add links to other relevant resources that give reviewers context to your changes: Figma, Miro boards, project documentation, etc.-->
+
+---
+
+### **Checklist**
+
+<!-- The following requirements must be met before you can merge your PR:-->
+
+- [ ] I have updated the README or other project documentation (if necessary).
+
+---


### PR DESCRIPTION
- Add FE PR template for use on all repos at Mole Street
- Note that this is a starting point, we should treat this as a living document to be updated as needed