### PR TITLE
Chore: Add Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,7 +12,5 @@ updates:
       interval: weekly
     allow:
       - dependency-type: direct
-    ignore:
-      - dependency-type: indirect
     open-pull-requests-limit: 5
 

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,18 @@
+
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+    allow:
+      - dependency-type: direct
+    ignore:
+      - dependency-type: indirect
+    open-pull-requests-limit: 5
+


### PR DESCRIPTION
This PR adds a basic `.github/dependabot.yml` to enable weekly updates for direct npm dependencies.